### PR TITLE
Update pywemo command for version >=1.0.0

### DIFF
--- a/octoprint_psucontrol_wemo/__init__.py
+++ b/octoprint_psucontrol_wemo/__init__.py
@@ -70,7 +70,7 @@ class PSUControl_Wemo(octoprint.plugin.StartupPlugin,
                 port = pywemo.ouimeaux_device.probe_wemo(plugip)
             url = "http://{}:{}/setup.xml".format(plugip, port)
             url = url.replace(':None', '')
-            device = pywemo.discovery.device_from_description(url, None)
+            device = pywemo.discovery.device_from_description(url)
 
             if cmd == "info":
                 return device.get_state()


### PR DESCRIPTION
pywemo updated the arguments for device_from_description() changing the 2nd arg to a keyword only arg in version 1.0.0. This produced an error for this plugin in the log: "TypeError: device_from_description() takes 1 positional argument but 2 were given"

Removing the 2nd arg allows everything to work properly again with recent versions of pywemo.

For reference, here is the commit where the change occurred:
https://github.com/pywemo/pywemo/commit/45f3b6022b6b01c41f3d438fac7243f6d972eacf
